### PR TITLE
pc - add configuration needed for git commit info to work

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/ExampleApplication.java
+++ b/src/main/java/edu/ucsb/cs156/example/ExampleApplication.java
@@ -8,6 +8,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.core.io.ClassPathResource;
 
 import edu.ucsb.cs156.example.services.wiremock.WiremockService;
 import lombok.extern.slf4j.Slf4j;
@@ -55,5 +57,21 @@ public class ExampleApplication {
    */
   public static void main(String[] args) {
     SpringApplication.run(ExampleApplication.class, args);
+  }
+
+  /** 
+   * Pull in git.properties from the classpath, if it exists. 
+   * This is useful for displaying git information in the application.
+   * We use this in the SystemInfoService.
+   * See: https://www.baeldung.com/spring-git-information
+   *  @return a propertySourcePlaceholderConfigurer for git.properties
+   */
+  @Bean
+  public static PropertySourcesPlaceholderConfigurer placeholderConfigurer() {
+    PropertySourcesPlaceholderConfigurer propsConfig = new PropertySourcesPlaceholderConfigurer();
+    propsConfig.setLocation(new ClassPathResource("git.properties"));
+    propsConfig.setIgnoreResourceNotFound(true);
+    propsConfig.setIgnoreUnresolvablePlaceholders(true);
+    return propsConfig;
   }
 }


### PR DESCRIPTION
In this PR, we fix the git commit info which was broken in this repo.

We were missing step 2 from these instructions:

* <https://ucsb-cs156.github.io/topics/maven/maven_git_commit_id_maven_plugin.html>

Deployed to:  https://team01.dokku-00.cs.ucsb.edu

Test Plan: 

* Access: <https://team01.dokku-00.cs.ucsb.edu/api/systemInfo>
* You should see the commit id of this the last commit on this PR.
