### PR TITLE
pc - update workflow 01 to use central workflow, and add workflow 00

### DIFF
--- a/.github/workflows/00-all-checks-pass.yml
+++ b/.github/workflows/00-all-checks-pass.yml
@@ -1,0 +1,42 @@
+name: 00 - All Checks Pass
+
+# This workflow checks if all required checks have passed before allowing a pull request to be merged.
+# It is triggered on pull request events and uses the GitHub CLI to check the status of checks.
+# The workflow will wait for all other checks to finish before proceeding.
+# If any of the required checks fail, the workflow will exit with an error.
+
+
+# This workflow updates the open PRs in
+# _config.yml each time a pull request is made
+# or there is a push to main.  It does not handle
+# the rebuild of the storybook or javadoc; that's handled
+# separately based on which files were modified.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+          
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+  pull-requests: read
+
+
+# The name "enforce" for this job is important; do not change it. The
+# ucsb-cs156/workflows repository expects this name in order to
+# identify this job.  It is also used in the "Required checks" section
+# of the branch protection rules for the main branch.
+
+jobs:
+  enforce: # the name "enforce" is important here; do not change it (see above)
+    uses: ucsb-cs156/workflows/.github/workflows/00-all-checks-pass.yml@main
+    secrets: 
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+

--- a/.github/workflows/01-gh-pages-pr-table.yml
+++ b/.github/workflows/01-gh-pages-pr-table.yml
@@ -14,8 +14,6 @@ on:
     branches:
       - main
           
-env:
-  GH_TOKEN: ${{ github.token }}
 
 permissions:
   contents: write
@@ -23,64 +21,10 @@ permissions:
   id-token: write
   pull-requests: read
 
-jobs: 
-  get-pull-requests:
-    name: Get Pull Requests
-    runs-on: ubuntu-latest
-    outputs:
-      pull_requests: ${{ steps.get-prs.outputs.pull_requests }}
-    steps:
-    - name: Checkout local code to establish repo
-      uses: actions/checkout@v4
-    - name: Get Pull Requests from Github api
-      id: get-prs
-      run: |
-         gh pr list -s open --json url,author,number,title,headRefName 
-         gh pr list -s open --json url,author,number,title,headRefName > prs.json
-         cat prs.json
-         pull_requests=`cat prs.json`
-         echo "pull_requests=${pull_requests}"
-         echo "pull_requests=${pull_requests}" >> "$GITHUB_OUTPUT"
-  build-basic-site:
-    name: Build Basic Site
-    runs-on: ubuntu-latest
-    needs: [get-pull-requests]
 
-    steps:
-    - name: Checkout local code to establish repo
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 1
+jobs:
+  call-workflow-passing-data:
+    uses: ucsb-cs156/workflows/.github/workflows/01-gh-pages-pr-table.yml@main
+    secrets: 
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
 
-    - name: Append name of site to _config.yml
-      run: | 
-          CONFIG_YML=docs-index/_config.yml
-          OWNER_PLUS_REPOSITORY=${{github.repository}}
-          OWNER=${{ github.repository_owner }}
-          REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
-          echo "repo: ${OWNER_PLUS_REPOSITORY}" >> ${CONFIG_YML}
-          echo "owner: ${OWNER}" >> ${CONFIG_YML}
-          echo "repo_name: ${REPOSITORY}" >> ${CONFIG_YML}    
-          cat ${CONFIG_YML}
-    - name: Store PRs as JSON in _config.yml
-      run: |
-         pull_requests=${{toJSON(needs.get-pull-requests.outputs.pull_requests)}}
-         CONFIG_YML=docs-index/_config.yml
-         echo "pull_requests: ${pull_requests}, CONFIG_YML: ${CONFIG_YML}"
-         echo "pull_requests: ${pull_requests}" >> ${CONFIG_YML}
-         cat ${CONFIG_YML}
-    - name: Compose web site
-      run: |
-        mkdir -p site
-        cp -r docs-index/* site
-  
-    - name: Deploy 🚀
-      uses: Wandalen/wretry.action@master
-      with:
-        action: JamesIves/github-pages-deploy-action@v4
-        attempt_limit: 3
-        attempt_delay: 5000
-        with: |
-          folder: site # The folder the action should deploy.
-          branch: gh-pages
-          clean: false


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use reusable workflows from the `ucsb-cs156/workflows` repository, simplifying maintenance and ensuring consistency. The changes primarily affect `.github/workflows/00-all-checks-pass.yml` and `.github/workflows/01-gh-pages-pr-table.yml`, replacing custom job definitions with calls to shared workflows and updating secrets configuration.

**Workflow modernization and simplification:**

* Added a new workflow file `.github/workflows/00-all-checks-pass.yml` that uses the reusable workflow from `ucsb-cs156/workflows` to enforce that all required checks pass before merging a pull request. This centralizes enforcement logic and reduces duplication.
* Refactored `.github/workflows/01-gh-pages-pr-table.yml` to call the shared workflow from `ucsb-cs156/workflows`, removing all custom job and step definitions related to pull request table generation and site deployment. This streamlines the workflow and ensures it stays up to date with upstream improvements.

**Secrets and permissions updates:**

* Updated secrets configuration in both workflow files to use `${{ secrets.GITHUB_TOKEN }}` for authentication, aligning with best practices for reusable workflows. [[1]](diffhunk://#diff-341721990db437a4c79845ba3456969c1883cb7a4d1116e53a99a46b54aaffe1R1-R42) [[2]](diffhunk://#diff-68d4f33cd0e6172353433fb1796adb0028d4bad2a56dce685dd2a5501c711f79L17-L86)
* Explicitly set permissions for contents, pages, id-token, and pull-requests in both workflows to ensure proper access control. [[1]](diffhunk://#diff-341721990db437a4c79845ba3456969c1883cb7a4d1116e53a99a46b54aaffe1R1-R42) [[2]](diffhunk://#diff-68d4f33cd0e6172353433fb1796adb0028d4bad2a56dce685dd2a5501c711f79L17-L86)