### PR TITLE
pc - update Dockerfile to use -ntp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN curl --version
 
 COPY . /home/app
 
-RUN mvn -B -Pproduction -DskipTests -f /home/app/pom.xml clean package
+RUN mvn -ntp -B -Pproduction -DskipTests -f /home/app/pom.xml clean package
 
 RUN ["chmod", "+x", "/home/app/startup.sh"]
 ENTRYPOINT ["/home/app/startup.sh","/home/app/target/team01-1.0.0.jar"]


### PR DESCRIPTION
In this PR, we update the Dockerfile to use -ntp on the mvn command to reduce the amount of unnecessary output.