### PR TITLE
pc - run vscode 'reorganize imports' on every Java source file

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/ExampleApplication.java
+++ b/src/main/java/edu/ucsb/cs156/example/ExampleApplication.java
@@ -6,10 +6,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
-import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import edu.ucsb.cs156.example.services.wiremock.WiremockService;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/edu/ucsb/cs156/example/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/example/config/SecurityConfig.java
@@ -1,45 +1,6 @@
 package edu.ucsb.cs156.example.config;
 
-import edu.ucsb.cs156.example.entities.User;
-import edu.ucsb.cs156.example.repositories.UserRepository;
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
-import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
-import org.springframework.security.config.Customizer;
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
-import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
-import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
-import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
-import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
-import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
-import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
-import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
-import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
-import org.springframework.security.web.csrf.CsrfTokenRequestHandler;
-import org.springframework.security.web.csrf.XorCsrfTokenRequestAttributeHandler;
-import org.springframework.security.web.csrf.CsrfToken;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-import org.springframework.util.StringUtils;
-import org.springframework.web.filter.OncePerRequestFilter;
-
 import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
-
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -49,6 +10,40 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+import org.springframework.security.web.csrf.CsrfTokenRequestHandler;
+import org.springframework.security.web.csrf.XorCsrfTokenRequestAttributeHandler;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import edu.ucsb.cs156.example.entities.User;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * The `SecurityConfig` class in Java configures web security with OAuth2 login,

--- a/src/main/java/edu/ucsb/cs156/example/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ApiController.java
@@ -1,16 +1,16 @@
 package edu.ucsb.cs156.example.controllers;
 
-import edu.ucsb.cs156.example.errors.EntityNotFoundException;
-import org.springframework.beans.factory.annotation.Autowired;
+import java.util.Map;
 
-import edu.ucsb.cs156.example.models.CurrentUser;
-import edu.ucsb.cs156.example.services.CurrentUserService;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-import java.util.Map;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.models.CurrentUser;
+import edu.ucsb.cs156.example.services.CurrentUserService;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * This is an abstract class that provides common functionality for all API controllers.

--- a/src/main/java/edu/ucsb/cs156/example/controllers/CSRFController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/CSRFController.java
@@ -5,7 +5,6 @@ import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-  
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 

--- a/src/main/java/edu/ucsb/cs156/example/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/JobsController.java
@@ -1,17 +1,7 @@
 package edu.ucsb.cs156.example.controllers;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import edu.ucsb.cs156.example.entities.Job;
-import edu.ucsb.cs156.example.errors.EntityNotFoundException;
-import edu.ucsb.cs156.example.jobs.TestJob;
-import edu.ucsb.cs156.example.repositories.JobsRepository;
-import edu.ucsb.cs156.example.services.jobs.JobService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -21,6 +11,19 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.ucsb.cs156.example.entities.Job;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.jobs.TestJob;
+import edu.ucsb.cs156.example.repositories.JobsRepository;
+import edu.ucsb.cs156.example.services.jobs.JobService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
 
 @Tag(name = "Jobs")
 @RequestMapping("/api/jobs")

--- a/src/main/java/edu/ucsb/cs156/example/controllers/RestaurantsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RestaurantsController.java
@@ -1,13 +1,5 @@
 package edu.ucsb.cs156.example.controllers;
 
-import edu.ucsb.cs156.example.entities.Restaurant;
-import edu.ucsb.cs156.example.errors.EntityNotFoundException;
-import edu.ucsb.cs156.example.repositories.RestaurantRepository;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -19,6 +11,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import edu.ucsb.cs156.example.entities.Restaurant;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.RestaurantRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
 /**

--- a/src/main/java/edu/ucsb/cs156/example/controllers/SystemInfoController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/SystemInfoController.java
@@ -1,15 +1,14 @@
 package edu.ucsb.cs156.example.controllers;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import edu.ucsb.cs156.example.models.SystemInfo;
 import edu.ucsb.cs156.example.services.SystemInfoService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 /**
  * This is a REST controller for getting information about the system.

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDatesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDatesController.java
@@ -1,15 +1,6 @@
 package edu.ucsb.cs156.example.controllers;
 
-import edu.ucsb.cs156.example.entities.UCSBDate;
-import edu.ucsb.cs156.example.errors.EntityNotFoundException;
-import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.extern.slf4j.Slf4j;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
+import java.time.LocalDateTime;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -23,9 +14,16 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import jakarta.validation.Valid;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
-import java.time.LocalDateTime;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * This is a REST controller for UCSBDates

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsController.java
@@ -1,14 +1,5 @@
 package edu.ucsb.cs156.example.controllers;
 
-import edu.ucsb.cs156.example.entities.UCSBDiningCommons;
-import edu.ucsb.cs156.example.errors.EntityNotFoundException;
-import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsRepository;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -20,7 +11,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import edu.ucsb.cs156.example.entities.UCSBDiningCommons;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * This is a REST controller for UCSBDiningCommons

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UserInfoController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UserInfoController.java
@@ -1,14 +1,13 @@
 package edu.ucsb.cs156.example.controllers;
 
-import edu.ucsb.cs156.example.models.CurrentUser;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import edu.ucsb.cs156.example.models.CurrentUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 /**
  * This is a REST controller for getting information about the current user.

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UsersController.java
@@ -1,14 +1,14 @@
 package edu.ucsb.cs156.example.controllers;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.ucsb.cs156.example.entities.User;
 import edu.ucsb.cs156.example.repositories.UserRepository;

--- a/src/main/java/edu/ucsb/cs156/example/entities/Job.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/Job.java
@@ -1,12 +1,27 @@
 package edu.ucsb.cs156.example.entities;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import jakarta.persistence.*;
 import java.time.ZonedDateTime;
-import lombok.*;
+
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDate.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDate.java
@@ -1,5 +1,7 @@
 package edu.ucsb.cs156.example.entities;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -8,8 +10,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 /**
  * This is a JPA entity that represents a UCSBDate, i.e. an entry

--- a/src/main/java/edu/ucsb/cs156/example/jobs/TestJob.java
+++ b/src/main/java/edu/ucsb/cs156/example/jobs/TestJob.java
@@ -1,10 +1,11 @@
 package edu.ucsb.cs156.example.jobs;
 
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
 import edu.ucsb.cs156.example.services.jobs.JobContext;
 import edu.ucsb.cs156.example.services.jobs.JobContextConsumer;
 import lombok.Builder;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 @Builder
 public class TestJob implements JobContextConsumer {

--- a/src/main/java/edu/ucsb/cs156/example/models/CurrentUser.java
+++ b/src/main/java/edu/ucsb/cs156/example/models/CurrentUser.java
@@ -1,16 +1,15 @@
 package edu.ucsb.cs156.example.models;
 
-import lombok.Data;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import lombok.Builder;
-import lombok.AccessLevel;
-
+import java.util.Collection;
 
 import org.springframework.security.core.GrantedAuthority;
-import edu.ucsb.cs156.example.entities.User;
 
-import java.util.Collection;
+import edu.ucsb.cs156.example.entities.User;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * This is a model class that represents the current user.

--- a/src/main/java/edu/ucsb/cs156/example/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/example/models/SystemInfo.java
@@ -1,10 +1,10 @@
 package edu.ucsb.cs156.example.models;
 
-import lombok.Data;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import lombok.Builder;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * This is a model class that represents system information.

--- a/src/main/java/edu/ucsb/cs156/example/repositories/JobsRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/JobsRepository.java
@@ -1,8 +1,9 @@
 package edu.ucsb.cs156.example.repositories;
 
-import edu.ucsb.cs156.example.entities.Job;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
+
+import edu.ucsb.cs156.example.entities.Job;
 
 @Repository
 public interface JobsRepository extends CrudRepository<Job, Long> {}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/RestaurantRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/RestaurantRepository.java
@@ -1,9 +1,9 @@
 package edu.ucsb.cs156.example.repositories;
 
-import edu.ucsb.cs156.example.entities.Restaurant;
-
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
+
+import edu.ucsb.cs156.example.entities.Restaurant;
 
 /**
  * The RestaurantRepository is a repository for Restaurant entities

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDateRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDateRepository.java
@@ -1,9 +1,9 @@
 package edu.ucsb.cs156.example.repositories;
 
-import edu.ucsb.cs156.example.entities.UCSBDate;
-
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
+
+import edu.ucsb.cs156.example.entities.UCSBDate;
 
 /**
  * The UCSBDateRepository is a repository for UCSBDate entities.

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsRepository.java
@@ -1,10 +1,9 @@
 package edu.ucsb.cs156.example.repositories;
 
-import edu.ucsb.cs156.example.entities.UCSBDiningCommons;
-
-import org.springframework.beans.propertyeditors.StringArrayPropertyEditor;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
+
+import edu.ucsb.cs156.example.entities.UCSBDiningCommons;
 
 /**
  * The UCSBDiningCommonsRepository is a repository for UCSBDiningCommons entities

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UserRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UserRepository.java
@@ -1,10 +1,11 @@
 package edu.ucsb.cs156.example.repositories;
 
-import edu.ucsb.cs156.example.entities.User;
+import java.util.Optional;
+
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import edu.ucsb.cs156.example.entities.User;
 
 /**
  * The UserRepository is a repository for User entities.

--- a/src/main/java/edu/ucsb/cs156/example/services/CurrentUserService.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/CurrentUserService.java
@@ -1,12 +1,12 @@
 package edu.ucsb.cs156.example.services;
 
-import edu.ucsb.cs156.example.entities.User;
-import edu.ucsb.cs156.example.models.CurrentUser;
-
 import java.util.Collection;
 import java.util.List;
 
 import org.springframework.security.core.GrantedAuthority;
+
+import edu.ucsb.cs156.example.entities.User;
+import edu.ucsb.cs156.example.models.CurrentUser;
 
 /**
  * This is a service that provides information about the current user.

--- a/src/main/java/edu/ucsb/cs156/example/services/CurrentUserServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/CurrentUserServiceImpl.java
@@ -1,10 +1,5 @@
 package edu.ucsb.cs156.example.services;
 
-import edu.ucsb.cs156.example.entities.User;
-import edu.ucsb.cs156.example.models.CurrentUser;
-import edu.ucsb.cs156.example.repositories.UserRepository;
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -20,6 +15,11 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.example.entities.User;
+import edu.ucsb.cs156.example.models.CurrentUser;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * This is a service that provides information about the current user.

--- a/src/main/java/edu/ucsb/cs156/example/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/SystemInfoServiceImpl.java
@@ -1,10 +1,11 @@
 package edu.ucsb.cs156.example.services;
 
-import edu.ucsb.cs156.example.models.SystemInfo;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.example.models.SystemInfo;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * This is a service for getting information about the system.

--- a/src/main/java/edu/ucsb/cs156/example/services/jobs/JobService.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/jobs/JobService.java
@@ -1,12 +1,13 @@
 package edu.ucsb.cs156.example.services.jobs;
 
-import edu.ucsb.cs156.example.entities.Job;
-import edu.ucsb.cs156.example.repositories.JobsRepository;
-import edu.ucsb.cs156.example.services.CurrentUserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.example.entities.Job;
+import edu.ucsb.cs156.example.repositories.JobsRepository;
+import edu.ucsb.cs156.example.services.CurrentUserService;
 
 @Service
 public class JobService {

--- a/src/main/java/edu/ucsb/cs156/example/services/wiremock/WiremockServiceDummy.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/wiremock/WiremockServiceDummy.java
@@ -1,12 +1,13 @@
 package edu.ucsb.cs156.example.services.wiremock;
 
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * This is a dummy service for profiles besides wiremock where we do not want the mocked authentication,

--- a/src/main/java/edu/ucsb/cs156/example/services/wiremock/WiremockServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/wiremock/WiremockServiceImpl.java
@@ -1,14 +1,5 @@
 package edu.ucsb.cs156.example.services.wiremock;
 
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Service;
-
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
-import com.github.tomakehurst.wiremock.junit.Stubbing;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
@@ -17,6 +8,15 @@ import static com.github.tomakehurst.wiremock.client.WireMock.temporaryRedirect;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.junit.Stubbing;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * This is a service for mocking authentication using wiremock

--- a/src/test/java/edu/ucsb/cs156/example/ControllerTestCase.java
+++ b/src/test/java/edu/ucsb/cs156/example/ControllerTestCase.java
@@ -1,22 +1,22 @@
 package edu.ucsb.cs156.example;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.UnsupportedEncodingException;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.ucsb.cs156.example.services.CurrentUserService;
 import edu.ucsb.cs156.example.services.GrantedAuthoritiesService;
 import edu.ucsb.cs156.example.services.wiremock.WiremockService;
 import edu.ucsb.cs156.example.testconfig.TestConfig;
-import org.springframework.test.web.servlet.MvcResult;
-
-import java.io.UnsupportedEncodingException;
-import java.util.Map;
 
 @ActiveProfiles("test")
 @Import(TestConfig.class)

--- a/src/test/java/edu/ucsb/cs156/example/WebTestCase.java
+++ b/src/test/java/edu/ucsb/cs156/example/WebTestCase.java
@@ -1,13 +1,7 @@
 package edu.ucsb.cs156.example;
 
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
-import com.microsoft.playwright.Browser;
-import com.microsoft.playwright.BrowserContext;
-import com.microsoft.playwright.BrowserType;
-import com.microsoft.playwright.Page;
-import com.microsoft.playwright.Playwright;
-import edu.ucsb.cs156.example.services.wiremock.WiremockServiceImpl;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -15,7 +9,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+
+import edu.ucsb.cs156.example.services.wiremock.WiremockServiceImpl;
 
 @ActiveProfiles("integration")
 public abstract class WebTestCase {

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ApiControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ApiControllerTests.java
@@ -1,8 +1,10 @@
 package edu.ucsb.cs156.example.controllers;
 
-import edu.ucsb.cs156.example.testconfig.TestConfig;
-import edu.ucsb.cs156.example.ControllerTestCase;
-import edu.ucsb.cs156.example.repositories.UserRepository;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -10,12 +12,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MvcResult;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
 
 @WebMvcTest(controllers = DummyController.class)
 @Import(TestConfig.class)

--- a/src/test/java/edu/ucsb/cs156/example/controllers/CSRFControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/CSRFControllerTests.java
@@ -1,26 +1,19 @@
 package edu.ucsb.cs156.example.controllers;
 
-import edu.ucsb.cs156.example.ControllerTestCase;
-import edu.ucsb.cs156.example.repositories.UserRepository;
-import edu.ucsb.cs156.example.testconfig.TestConfig;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import org.aspectj.lang.annotation.Before;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
 
 @ActiveProfiles("development")
 @WebMvcTest(controllers = CSRFController.class)

--- a/src/test/java/edu/ucsb/cs156/example/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/JobsControllerTests.java
@@ -3,10 +3,13 @@ package edu.ucsb.cs156.example.controllers;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -14,27 +17,29 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import edu.ucsb.cs156.example.ControllerTestCase;
 import edu.ucsb.cs156.example.entities.Job;
 import edu.ucsb.cs156.example.entities.User;
 import edu.ucsb.cs156.example.repositories.JobsRepository;
 import edu.ucsb.cs156.example.repositories.UserRepository;
 import edu.ucsb.cs156.example.services.jobs.JobService;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
-import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MvcResult;
 
 @Slf4j
 @WebMvcTest(controllers = JobsController.class)

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RestaurantsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RestaurantsControllerTests.java
@@ -1,14 +1,23 @@
 package edu.ucsb.cs156.example.controllers;
 
-import edu.ucsb.cs156.example.repositories.UserRepository;
-import edu.ucsb.cs156.example.testconfig.TestConfig;
-import edu.ucsb.cs156.example.ControllerTestCase;
-import edu.ucsb.cs156.example.entities.Restaurant;
-import edu.ucsb.cs156.example.repositories.RestaurantRepository;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -17,18 +26,11 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.Restaurant;
+import edu.ucsb.cs156.example.repositories.RestaurantRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
 
 @WebMvcTest(controllers = RestaurantsController.class)
 @Import(TestConfig.class)

--- a/src/test/java/edu/ucsb/cs156/example/controllers/SystemInfoControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/SystemInfoControllerTests.java
@@ -1,20 +1,19 @@
 package edu.ucsb.cs156.example.controllers;
 
-import edu.ucsb.cs156.example.ControllerTestCase;
-import edu.ucsb.cs156.example.models.SystemInfo;
-import edu.ucsb.cs156.example.repositories.UserRepository;
-import edu.ucsb.cs156.example.services.SystemInfoService;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.models.SystemInfo;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.services.SystemInfoService;
 
 @WebMvcTest(controllers = SystemInfoController.class)
 public class SystemInfoControllerTests extends ControllerTestCase {

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDatesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDatesControllerTests.java
@@ -1,14 +1,24 @@
 package edu.ucsb.cs156.example.controllers;
 
-import edu.ucsb.cs156.example.repositories.UserRepository;
-import edu.ucsb.cs156.example.testconfig.TestConfig;
-import edu.ucsb.cs156.example.ControllerTestCase;
-import edu.ucsb.cs156.example.entities.UCSBDate;
-import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -17,20 +27,11 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-
-import java.time.LocalDateTime;
-
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
 
 @WebMvcTest(controllers = UCSBDatesController.class)
 @Import(TestConfig.class)

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsControllerTests.java
@@ -1,14 +1,23 @@
 package edu.ucsb.cs156.example.controllers;
 
-import edu.ucsb.cs156.example.repositories.UserRepository;
-import edu.ucsb.cs156.example.testconfig.TestConfig;
-import edu.ucsb.cs156.example.ControllerTestCase;
-import edu.ucsb.cs156.example.entities.UCSBDiningCommons;
-import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsRepository;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -17,18 +26,11 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommons;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
 
 @WebMvcTest(controllers = UCSBDiningCommonsController.class)
 @Import(TestConfig.class)

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UserInfoControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UserInfoControllerTests.java
@@ -1,9 +1,8 @@
 package edu.ucsb.cs156.example.controllers;
 
-import edu.ucsb.cs156.example.ControllerTestCase;
-import edu.ucsb.cs156.example.models.CurrentUser;
-import edu.ucsb.cs156.example.repositories.UserRepository;
-import edu.ucsb.cs156.example.testconfig.TestConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -12,9 +11,10 @@ import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.models.CurrentUser;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
 
 @WebMvcTest(controllers = UserInfoController.class)
 @Import(TestConfig.class)

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UsersControllerTests.java
@@ -1,9 +1,14 @@
 package edu.ucsb.cs156.example.controllers;
 
-import edu.ucsb.cs156.example.ControllerTestCase;
-import edu.ucsb.cs156.example.entities.User;
-import edu.ucsb.cs156.example.repositories.UserRepository;
-import edu.ucsb.cs156.example.testconfig.TestConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ArrayList;
+import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -12,15 +17,10 @@ import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import java.util.ArrayList;
-import java.util.Arrays;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.User;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
 
 @WebMvcTest(controllers = UsersController.class)
 @Import(TestConfig.class)

--- a/src/test/java/edu/ucsb/cs156/example/integration/RestaurantIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/integration/RestaurantIT.java
@@ -1,6 +1,10 @@
 package edu.ucsb.cs156.example.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,10 +22,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 
 import edu.ucsb.cs156.example.entities.Restaurant;
 import edu.ucsb.cs156.example.repositories.RestaurantRepository;

--- a/src/test/java/edu/ucsb/cs156/example/services/CurrentUserServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/services/CurrentUserServiceTests.java
@@ -6,10 +6,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 
 import edu.ucsb.cs156.example.ControllerTestCase;
 import edu.ucsb.cs156.example.entities.User;
-import org.mockito.Answers;
 
 class CurrentUserServiceTests extends ControllerTestCase {
 

--- a/src/test/java/edu/ucsb/cs156/example/services/JobLogsServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/services/JobLogsServiceTests.java
@@ -2,15 +2,19 @@ package edu.ucsb.cs156.example.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 import edu.ucsb.cs156.example.entities.Job;
 import edu.ucsb.cs156.example.repositories.JobsRepository;
 import edu.ucsb.cs156.example.services.jobs.JobService;
-import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.*;
 
 public class JobLogsServiceTests {
 

--- a/src/test/java/edu/ucsb/cs156/example/services/jobs/JobContextTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/services/jobs/JobContextTests.java
@@ -1,8 +1,10 @@
 package edu.ucsb.cs156.example.services.jobs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import edu.ucsb.cs156.example.entities.Job;
+
 import org.junit.jupiter.api.Test;
+
+import edu.ucsb.cs156.example.entities.Job;
 
 
 public class JobContextTests {

--- a/src/test/java/edu/ucsb/cs156/example/testconfig/MockCurrentUserServiceImpl.java
+++ b/src/test/java/edu/ucsb/cs156/example/testconfig/MockCurrentUserServiceImpl.java
@@ -1,8 +1,5 @@
 package edu.ucsb.cs156.example.testconfig;
 
-import edu.ucsb.cs156.example.entities.User;
-import edu.ucsb.cs156.example.services.CurrentUserServiceImpl;
-
 import java.util.Collection;
 import java.util.List;
 
@@ -13,6 +10,9 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.example.entities.User;
+import edu.ucsb.cs156.example.services.CurrentUserServiceImpl;
 
 @Service("testingUser")
 public class MockCurrentUserServiceImpl extends CurrentUserServiceImpl {

--- a/src/test/java/edu/ucsb/cs156/example/testconfig/TestConfig.java
+++ b/src/test/java/edu/ucsb/cs156/example/testconfig/TestConfig.java
@@ -1,13 +1,12 @@
 package edu.ucsb.cs156.example.testconfig;
 
-import edu.ucsb.cs156.example.config.SecurityConfig;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 
-
+import edu.ucsb.cs156.example.config.SecurityConfig;
 import edu.ucsb.cs156.example.services.CurrentUserService;
 import edu.ucsb.cs156.example.services.GrantedAuthoritiesService;
-import org.springframework.context.annotation.Import;
 
 @TestConfiguration
 @Import(SecurityConfig.class)

--- a/src/test/java/edu/ucsb/cs156/example/web/HomePageWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/HomePageWebIT.java
@@ -1,5 +1,7 @@
 package edu.ucsb.cs156.example.web;
 
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -15,7 +17,6 @@ import com.microsoft.playwright.BrowserContext;
 import com.microsoft.playwright.BrowserType;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
-import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)

--- a/src/test/java/edu/ucsb/cs156/example/web/SwaggerWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/SwaggerWebIT.java
@@ -1,5 +1,7 @@
 package edu.ucsb.cs156.example.web;
 
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,8 +18,6 @@ import com.microsoft.playwright.BrowserType;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
 import com.microsoft.playwright.options.AriaRole;
-
-import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)


### PR DESCRIPTION
In this PR, we close #12 by running the VSCode "reorganize imports" command on every source file.

