### PR TITLE
Workflow to Validate Migration Files

### DIFF
--- a/.github/workflows/18-validate-db-schema.yml
+++ b/.github/workflows/18-validate-db-schema.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   call-validate-db-schema:
-    uses: ucsb-cs156/workflows/.github/workflows/18-validate-db-schema.yml@dj-enforceSchemaValidations
+    uses: ucsb-cs156/workflows/.github/workflows/18-validate-db-schema.yml@main
     with:
       JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION || 'temurin' }}
     secrets:

--- a/.github/workflows/18-validate-db-schema.yml
+++ b/.github/workflows/18-validate-db-schema.yml
@@ -1,0 +1,23 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: "18-validate-db-schema: Ensure Migration File Matches Entity Files"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/18-validate-db-schema.yml]
+  push:
+    branches: [ main ]
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/18-validate-db-schema.yml]
+
+jobs:
+  call-validate-db-schema:
+    uses: ucsb-cs156/workflows/.github/workflows/18-validate-db-schema.yml@dj-enforceSchemaValidations
+    with:
+      JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION || 'temurin' }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+
+
+  

--- a/src/main/resources/db/migration/changes/Jobs.json
+++ b/src/main/resources/db/migration/changes/Jobs.json
@@ -1,0 +1,75 @@
+{ "databaseChangeLog": [
+  {
+    "changeSet": {
+      "id": "Jobs-0",
+      "author": "Division7 (generated)",
+      "preConditions": [
+        {
+          "onFail": "MARK_RAN"
+        },
+        {
+          "not": [
+            {
+              "tableExists": {
+                "tableName": "JOBS"
+              }
+            }
+          ]
+        }
+      ],
+      "changes": [
+        {
+          "createTable": {
+            "columns": [
+              {
+                "column": {
+                  "autoIncrement": true,
+                  "constraints": {
+                    "nullable": false,
+                    "primaryKey": true,
+                    "primaryKeyName": "JOB_PK"
+                  },
+                  "name": "ID",
+                  "type": "BIGINT"
+                }
+              },
+              {
+                "column": {
+                  "name": "CREATED_BY_ID",
+                  "type": "BIGINT"
+                }
+              },
+              {
+                "column": {
+                  "name": "CREATED_AT",
+                  "type": "TIMESTAMP"
+                }
+              },
+              {
+                "column": {
+                  "name": "UPDATED_AT",
+                  "type": "TIMESTAMP"
+                }
+              },
+              {
+                "column": {
+                  "name": "STATUS",
+                  "type": "VARCHAR(255)"
+                }
+              },
+              {
+                "column": {
+                  "name": "LOG",
+                  "type": "VARCHAR(1048576)"
+                }
+              }
+            ]
+          ,
+            "tableName": "JOBS"
+          }
+        }
+      ]
+
+    }
+  },
+]}


### PR DESCRIPTION
In this PR, I introduce a workflow that enforces that the entity files match with the database migrations to reduce friction during team01.

This requires that an actual jobs table is created via database migration, and requires forcibly setting the `ddl-auto` property via workflow.

Sister PR demonstrating bad change: https://github.com/ucsb-cs156-f25/STARTER-team01/pull/108


